### PR TITLE
Close cache connection on post-build

### DIFF
--- a/d2/plugin.py
+++ b/d2/plugin.py
@@ -29,6 +29,7 @@ class Plugin(BasePlugin[PluginConfig]):
             backend = dbm.whichdb(path)
             info(f"Using cache at {path} ({backend})")
             cache = dbm.open(path, "c")
+            self.config["cache"] = cache
 
         try:
             result = subprocess.run(
@@ -71,6 +72,12 @@ class Plugin(BasePlugin[PluginConfig]):
         }
 
         return config
+
+    def on_post_build(self, _) -> None:
+        cache = self.config.cache
+        if cache is not None:
+            info("Closing cache")
+            cache.close()
 
 
 def render(


### PR DESCRIPTION
When running `mkdocs serve`, the following error will appear on hot-reloading

```
Traceback (most recent call last):
  File "/Users/masked/.venv/lib/python3.12/site-packages/mkdocs/livereload/__init__.py", line 193, in _build_loop
    func()
  File "/Users/masked/.venv/lib/python3.12/site-packages/mkdocs/commands/serve.py", line 67, in builder
    build(config, live_server=None if is_clean else server, dirty=is_dirty)
  File "/Users/masked/.venv/lib/python3.12/site-packages/mkdocs/commands/build.py", line 277, in build
    config = config.plugins.on_config(config)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/masked/.venv/lib/python3.12/site-packages/mkdocs/plugins.py", line 527, in on_config
    return self.run_event('config', config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/masked/.venv/lib/python3.12/site-packages/mkdocs/plugins.py", line 507, in run_event
    result = method(item, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/masked/.venv/lib/python3.12/site-packages/d2/plugin.py", line 31, in on_config
    cache: _Database = dbm.open(path, "c")
                       ^^^^^^^^^^^^^^^^^^^
  File "/Users/masked/.pyenv/versions/3.12.0/lib/python3.12/dbm/__init__.py", line 95, in open
    return mod.open(file, flag, mode)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
_gdbm.error: [Errno 35] Resource temporarily unavailable: '.cache/plugin/d2/db'
ERROR   -  [11:37:09] An error happened during the rebuild. The server will appear stuck until build errors are resolved.
```

This PR attempts to fix it by closing the connection on post-build stage as suggested by mkdocs
<https://www.mkdocs.org/dev-guide/plugins/#on_post_build>