### PR TITLE
📈 Print file not found as debug instead of error

### DIFF
--- a/d2/__init__.py
+++ b/d2/__init__.py
@@ -5,6 +5,7 @@ from mkdocs.plugins import log
 
 NAME = "mkdocs-d2-plugin"
 
+debug = partial(log.debug, f"{NAME}: %s")
 info = partial(log.info, f"{NAME}: %s")
 warning = partial(log.warning, f"{NAME}: %s")
 error = partial(log.error, f"{NAME}: %s")

--- a/d2/img.py
+++ b/d2/img.py
@@ -7,7 +7,7 @@ from markdown import Extension, Markdown
 from markdown.treeprocessors import Treeprocessor
 from pydantic import ValidationError
 
-from d2 import Renderer, error, warning
+from d2 import Renderer, debug, error, warning
 from d2.config import D2Config
 
 
@@ -30,8 +30,10 @@ class D2ImgTreeprocessor(Treeprocessor):
             if src.suffix == ".d2":
                 diagram = Path(self.base_dir, src).resolve()
                 if not diagram.exists():
-                    error(f"File not found: {diagram}")
+                    debug(f"File not found: {src} in {self.base_dir}")
                     continue
+                else:
+                    debug(f"File found: {src} in {self.base_dir}")
                 with diagram.open("rb") as f:
                     source = f.read()
 


### PR DESCRIPTION
This PR changes the message level from ERROR to DEBUG when a diagram file is not found.

WHY: The current behavior creates a D2 image processor for each folder. Each folder is scanned for the diagrams, and errors are  raised even though the file is found. A small sample of a modified plugin, for a single included file:

```
ERROR   -  mkdocs-d2-plugin: File found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/posts/
ERROR   -  mkdocs-d2-plugin: File found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/posts/
ERROR   -  mkdocs-d2-plugin: File found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/posts/
ERROR   -  mkdocs-d2-plugin: File not found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/
ERROR   -  mkdocs-d2-plugin: File not found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/
ERROR   -  mkdocs-d2-plugin: File not found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/
ERROR   -  mkdocs-d2-plugin: File not found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/archive/
ERROR   -  mkdocs-d2-plugin: File not found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/archive/
ERROR   -  mkdocs-d2-plugin: File not found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/archive/
ERROR   -  mkdocs-d2-plugin: File not found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/category/
ERROR   -  mkdocs-d2-plugin: File not found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/category/
ERROR   -  mkdocs-d2-plugin: File not found: gitlab_runner_improved_registration/gitlab_runner_improved_registration_04.d2 in /workspaces/thoughts/docs/blog/category/
```

IMPROVEMENT: No more systematical false errors raised at compilation, hiding true errors.

REGRESSION: Errors aren't raised anymore when a file is not found anywhere.

There is space for improvement, if we can raise the error only where the file was not found in any scanned folder, but I'm not sure this can be done with the current architecture. This PR should be seen as a tactical improvement until a better fix is found.

To me, hiding true errors is less problematic than raising false errors everytime. WDYT?