### PR TITLE
fix: use file move in stead of read

### DIFF
--- a/d2/plugin.py
+++ b/d2/plugin.py
@@ -5,7 +5,7 @@ import subprocess
 import xml.etree.ElementTree as etree
 from functools import partial
 from hashlib import sha1
-from importlib.resources import files as importlib_files
+from importlib.resources import path as importlib_path
 from io import StringIO
 from pathlib import Path
 from typing import List, MutableMapping, Optional, Tuple, Union
@@ -93,12 +93,14 @@ class Plugin(BasePlugin[PluginConfig]):
             self.cache.close()
 
     def on_files(self, files: Files, config):
-        file = File(
-            "mkdocs_d2_plugin.css",
-            importlib_files("d2.css"),
-            Path(config["site_dir"]) / "assets/stylesheets",
-            config["use_directory_urls"],
-        )
+        with importlib_path(__name__, "css") as css_path:
+            print(f"Copying stylesheet from {css_path} to {config['site_dir']}")
+            file = File(
+                MKDOCS_D2_CSS,
+                css_path,
+                Path(config["site_dir"]) / STYLESHEET_LOCATION,
+                config["use_directory_urls"],
+            )
         files.append(file)
 
 

--- a/d2/plugin.py
+++ b/d2/plugin.py
@@ -22,8 +22,9 @@ from d2 import info, warning
 from d2.config import PluginConfig
 from d2.fence import D2CustomFence
 
+MKDOCS_D2_CSS = "mkdocs_d2_plugin.css"
 REQUIRED_VERSION = version.parse("0.6.3")
-
+STYLESHEET_LOCATION = "assets/stylesheets"
 
 class Plugin(BasePlugin[PluginConfig]):
     def on_config(self, config: MkDocsConfig) -> Optional[MkDocsConfig]:
@@ -83,7 +84,7 @@ class Plugin(BasePlugin[PluginConfig]):
             "renderer": renderer,
         }
 
-        config["extra_css"].append("assets/stylesheets/mkdocs_d2_plugin.css")
+        config["extra_css"].append(str(Path(STYLESHEET_LOCATION) / MKDOCS_D2_CSS))
 
         return config
 
@@ -92,15 +93,12 @@ class Plugin(BasePlugin[PluginConfig]):
             self.cache.close()
 
     def on_files(self, files: Files, config):
-        content = importlib_files("d2.css").joinpath("mkdocs_d2_plugin.css").read_text()
         file = File(
-            "assets/stylesheets/mkdocs_d2_plugin.css",
-            None,
-            config["site_dir"],
+            "mkdocs_d2_plugin.css",
+            importlib_files("d2.css"),
+            Path(config["site_dir"]) / "assets/stylesheets",
             config["use_directory_urls"],
         )
-        file.content_string = content
-
         files.append(file)
 
 


### PR DESCRIPTION
Allows the plugin to be used with mkdocs-same-dir. Alternative fix proposed in also https://github.com/oprypin/mkdocs-same-dir/pull/13. But this is a good change nonetheless. 